### PR TITLE
window(fix): fix window is undefined error in progress indicator

### DIFF
--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react';
 import Helmet from 'react-helmet';
-import { graphql } from 'gatsby';
+// import { graphql } from 'gatsby';
 import type { Node as ReactNode } from 'react';
 import styles from './Layout.module.scss';
 
@@ -23,7 +23,6 @@ const Layout = ({
   const cardImage = `${
     process.env.GATSBY_FEATURED_IMAGES_FOLDER_URL
   }${featuredImage || 'about/hello.jpg'}`;
-  console.log(process.env.GATSBY_FEATURED_IMAGES_FOLDER_URL);
   const cardType = featuredImage ? 'summary_large_image' : 'summary';
   return (
     <div className={styles.layout}>

--- a/src/components/ProgressIndicator/ProgressIndicator.js
+++ b/src/components/ProgressIndicator/ProgressIndicator.js
@@ -1,9 +1,11 @@
-import React, {
- useState, useEffect, useRef, useCallback 
-} from 'react';
-import styles from './ProgressIndicator.module.scss';
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import styles from "./ProgressIndicator.module.scss";
 
-function useEventListener(eventName, handler, element = window) {
+function useEventListener(
+  eventName,
+  handler,
+  element = typeof window !== "undefined" && window
+) {
   // Create a ref that stores handler
   const savedHandler = useRef();
 
@@ -23,7 +25,7 @@ function useEventListener(eventName, handler, element = window) {
       if (!isSupported) return;
 
       // Create event listener that calls handler function stored in ref
-      const eventListener = (event) => savedHandler.current(event);
+      const eventListener = event => savedHandler.current(event);
 
       // Add event listener
       element.addEventListener(eventName, eventListener);
@@ -38,7 +40,7 @@ function useEventListener(eventName, handler, element = window) {
 }
 
 const ProgressIndicator = () => {
-  const [scrollPercent, setScrollPercent] = useState('0%');
+  const [scrollPercent, setScrollPercent] = useState("0%");
 
   const handler = useCallback(() => {
     const scrollPercent = parseInt(
@@ -50,11 +52,11 @@ const ProgressIndicator = () => {
   }, [setScrollPercent]);
 
   // Add event listener using our hook
-  useEventListener('scroll', handler);
+  useEventListener("scroll", handler);
 
   return (
     <div
-      className={styles['progress-indicator']}
+      className={styles["progress-indicator"]}
       style={{
         background: `linear-gradient(to right,rgb(110, 110, 110) ${scrollPercent},transparent 0)`
       }}


### PR DESCRIPTION
## Description

Fixes build error

```
12:54:29 AM: error #95312 ReferenceError: window is not defined
12:54:29 AM: "window" is not available during server side rendering.
12:54:29 AM: See our docs page for more info on this error: https://gatsby.dev/debug-html
12:54:29 AM:   4 | import styles from './ProgressIndicator.module.scss';
12:54:29 AM:   5 |
12:54:29 AM: > 6 | function useEventListener(eventName, handler, element = window) {
12:54:29 AM:     |                                               ^
12:54:29 AM:   7 |   // Create a ref that stores handler
12:54:29 AM:   8 |   const savedHandler = useRef();
12:54:29 AM:   9 |
12:54:29 AM: 
12:54:29 AM:   WebpackError: ReferenceError: window is not defined
12:54:29 AM:   
12:54:29 AM:   - ProgressIndicator.js:6 useEventListener
12:54:29 AM:     src/components/ProgressIndicator/ProgressIndicator.js:6:47
12:54:29 AM:   
12:54:29 AM:   - ProgressIndicator.js:53 ProgressIndicator
12:54:29 AM:     src/components/ProgressIndicator/ProgressIndicator.js:53:3
12:54:29 AM:   
12:54:29 AM: 
12:54:30 AM: error Command failed with exit code 1.
```