### PR TITLE
dark mode(fix): move all control flow to scss

### DIFF
--- a/src/assets/scss/base/_generic.scss
+++ b/src/assets/scss/base/_generic.scss
@@ -35,6 +35,60 @@ body {
     color: $color-base;
   }
 
+  .feed__item-meta-category {
+    @include category;
+
+    & a {
+      @include category;
+      background-color: $color-primary;
+      text-decoration: none;
+    }
+  }
+
+  .page__title {
+    @include page-title;
+    @include text-shadow($color-primary);
+  }
+
+  .content__title {
+    @include content-title;
+    @include text-shadow($color-primary);
+  }
+
+  .tags__list-item-link {
+    @include post-tag;
+    background: $color-primary;
+    color: $color-base;
+
+    &:before {
+      content: '#';
+    }
+  }
+
+  .sidebar__inner {
+    position: relative;
+    padding: 25px 20px 0;
+
+    @include breakpoint-sm {
+      padding: 30px 20px 0;
+
+      &:after {
+        @include sidebar-divider;
+        background: $color-gray-border;
+        background: linear-gradient(
+          to bottom,
+          $color-gray-border 0%,
+          $color-gray-border 48%,
+          $color-white 100%
+        ) !important;
+      }
+    }
+
+    @include breakpoint-md {
+      padding: 40px;
+    }
+  }
+
   &.dark-mode {
     background: $color-base;
     color: $color-white;
@@ -69,10 +123,46 @@ body {
     .author__title-link {
       @include text-shadow($color-black);
     }
+
+    .feed__item-meta-category {
+      & a {
+        background-color: $color-black !important;
+        color: $color-gray !important;
+      }
+    }
+
+    .page__title {
+      @include text-shadow($color-black);
+    }
+
+    .content__title {
+      color: $color-white !important;
+      @include text-shadow($color-black);
+    }
+
+    .tags__list-item-link {
+      color: $color-gray !important;
+      background-color: $color-black;
+    }
+
+    .sidebar__inner {
+      &:after {
+        background: $color-gray-border;
+        background: linear-gradient(
+          to bottom,
+          darken($color-gray, 20%) 0%,
+          darken($color-gray, 20%) 48%,
+          $color-base 100%
+        ) !important;
+      }
+    }
   }
 
   
+
 }
+
+
 
 
 mark {
@@ -225,4 +315,3 @@ figcaption {
   }
 
 }
-

--- a/src/assets/scss/base/_generic.scss
+++ b/src/assets/scss/base/_generic.scss
@@ -21,6 +21,20 @@ body {
   -moz-osx-font-smoothing: grayscale;
   background-color: $color-white;
 
+  .feed__item-title-link {
+    color: $color-base;
+    text-decoration: none !important;
+
+    &:hover,
+    &:focus {
+      border-bottom: 1px solid $color-base;
+    }
+  }
+
+  .author__title-link {
+    color: $color-base;
+  }
+
   &.dark-mode {
     background: $color-base;
     color: $color-white;
@@ -46,7 +60,18 @@ body {
       background-color: $color-black;
       color: $color-white;
     }
+
+    .feed__item-title-link {
+      @include text-shadow($color-black);
+      text-decoration: none !important;
+    }
+
+    .author__title-link {
+      @include text-shadow($color-black);
+    }
   }
+
+  
 }
 
 
@@ -200,3 +225,4 @@ figcaption {
   }
 
 }
+

--- a/src/assets/scss/mixins/_components.scss
+++ b/src/assets/scss/mixins/_components.scss
@@ -14,14 +14,24 @@
 }
 
 @mixin content-title {
-  font-size: $typographic-base-font-size * 2;
+  @include breakpoint-md {
+    font-size: $typographic-base-font-size * 3;
+    @include line-height(2.25);
+    @include margin-top(2.25);
+    @include margin-bottom(1.5);
+  }
+
+  @include breakpoint-xs {
+    font-size: $typographic-base-font-size * 2;
+    @include line-height(1.65);
+    @include margin-top(1);
+    @include margin-bottom(0);
+  }
+
   max-width: $layout-post-width;
   margin-left: auto;
   margin-right: auto;
   font-weight: 600;
-  @include line-height(1.65);
-  @include margin-top(1);
-  @include margin-bottom(0);
 }
 
 @mixin page-title {

--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -2,6 +2,7 @@
 import React, { useContext } from 'react';
 import moment from 'moment';
 import { Link } from 'gatsby';
+import classNames from 'classnames/bind';
 import type { Edges } from '../../types';
 import styles from './Feed.module.scss';
 import ThemeContext from '../../context/theme-context';
@@ -11,8 +12,18 @@ type Props = {
   isDark?: boolean
 };
 
+const cx = classNames.bind(styles);
+
 const Feed = ({ edges }: Props) => {
   const { isDark } = useContext(ThemeContext);
+  console.log('From Feed', isDark);
+  const categoryClassName = cx({
+    'feed__item-meta-category': !isDark,
+    'feed__item-meta-category--dark': isDark
+  });
+
+  console.log(categoryClassName);
+
   return (
     <div className={styles['feed']}>
       {edges.map((edge) => (
@@ -20,11 +31,7 @@ const Feed = ({ edges }: Props) => {
           <div className={styles['feed__item-meta']}>
             {!!edge.node.frontmatter.category && (
               <>
-                <span
-                  className={
-                    styles[`feed__item-meta-category${isDark ? '--dark' : ''}`]
-                  }
-                >
+                <span className={categoryClassName}>
                   <Link to={edge.node.fields.categorySlug}>
                     {edge.node.frontmatter.category}
                   </Link>
@@ -33,12 +40,7 @@ const Feed = ({ edges }: Props) => {
             )}
           </div>
           <h2 className={styles['feed__item-title']}>
-            <Link
-              className={
-                styles[`feed__item-title-link${isDark ? '--dark' : ''}`]
-              }
-              to={edge.node.fields.slug}
-            >
+            <Link className='feed__item-title-link' to={edge.node.fields.slug}>
               {edge.node.frontmatter.title}
             </Link>
           </h2>

--- a/src/components/Feed/Feed.js
+++ b/src/components/Feed/Feed.js
@@ -1,37 +1,24 @@
 // @flow
-import React, { useContext } from 'react';
+import React from 'react';
 import moment from 'moment';
 import { Link } from 'gatsby';
 import classNames from 'classnames/bind';
 import type { Edges } from '../../types';
 import styles from './Feed.module.scss';
-import ThemeContext from '../../context/theme-context';
 
 type Props = {
   edges: Edges,
   isDark?: boolean
 };
 
-const cx = classNames.bind(styles);
-
-const Feed = ({ edges }: Props) => {
-  const { isDark } = useContext(ThemeContext);
-  console.log('From Feed', isDark);
-  const categoryClassName = cx({
-    'feed__item-meta-category': !isDark,
-    'feed__item-meta-category--dark': isDark
-  });
-
-  console.log(categoryClassName);
-
-  return (
-    <div className={styles['feed']}>
-      {edges.map((edge) => (
-        <div className={styles['feed__item']} key={edge.node.fields.slug}>
-          <div className={styles['feed__item-meta']}>
+const Feed = ({ edges }: Props) => (
+    <div className={styles["feed"]}>
+      {edges.map(edge => (
+        <div className={styles["feed__item"]} key={edge.node.fields.slug}>
+          <div className={styles["feed__item-meta"]}>
             {!!edge.node.frontmatter.category && (
               <>
-                <span className={categoryClassName}>
+                <span className='feed__item-meta-category'>
                   <Link to={edge.node.fields.categorySlug}>
                     {edge.node.frontmatter.category}
                   </Link>
@@ -39,13 +26,13 @@ const Feed = ({ edges }: Props) => {
               </>
             )}
           </div>
-          <h2 className={styles['feed__item-title']}>
+          <h2 className={styles["feed__item-title"]}>
             <Link className='feed__item-title-link' to={edge.node.fields.slug}>
               {edge.node.frontmatter.title}
             </Link>
           </h2>
-          <p className={styles['feed__item-description']}>
-            {edge.node.frontmatter.description}{' '}
+          <p className={styles["feed__item-description"]}>
+            {edge.node.frontmatter.description}{" "}
             {/* <Link
             className={styles['feed__item-readmore']}
             to={edge.node.fields.slug}
@@ -54,14 +41,14 @@ const Feed = ({ edges }: Props) => {
           </Link> */}
             <br />
             <time
-              className={styles['feed__item-meta-time']}
+              className={styles["feed__item-meta-time"]}
               dateTime={moment(edge.node.frontmatter.date).format(
-                'MMMM D, YYYY'
+                "MMMM D, YYYY"
               )}
             >
-              {moment(edge.node.frontmatter.date).format('MMM DD')}
+              {moment(edge.node.frontmatter.date).format("MMM DD")}
             </time>
-            <span className={styles['feed__item-meta-duration']}>
+            <span className={styles["feed__item-meta-duration"]}>
               ☕ {edge.node.timeToRead} min read
             </span>
           </p>
@@ -69,6 +56,5 @@ const Feed = ({ edges }: Props) => {
       ))}
     </div>
   );
-};
 
 export default Feed;

--- a/src/components/Feed/Feed.module.scss
+++ b/src/components/Feed/Feed.module.scss
@@ -18,20 +18,20 @@
         text-decoration: none !important;
       }
 
-      &-link {
-        color: $color-base;
-        text-decoration: none !important;
+      // &-link {
+      //   color: $color-base;
+      //   text-decoration: none !important;
 
-        &:hover,
-        &:focus {
-          border-bottom: 1px solid $color-base;
-        }
+      //   &:hover,
+      //   &:focus {
+      //     border-bottom: 1px solid $color-base;
+      //   }
 
-        &--dark {
-          @include text-shadow($color-black);
-          text-decoration: none !important;
-        }
-      }
+      //   &--dark {
+      //     @include text-shadow($color-black);
+      //     text-decoration: none !important;
+      //   }
+      // }
     }
 
     &-description {

--- a/src/components/Feed/Feed.module.scss
+++ b/src/components/Feed/Feed.module.scss
@@ -17,21 +17,6 @@
       & a {
         text-decoration: none !important;
       }
-
-      // &-link {
-      //   color: $color-base;
-      //   text-decoration: none !important;
-
-      //   &:hover,
-      //   &:focus {
-      //     border-bottom: 1px solid $color-base;
-      //   }
-
-      //   &--dark {
-      //     @include text-shadow($color-black);
-      //     text-decoration: none !important;
-      //   }
-      // }
     }
 
     &-description {
@@ -63,25 +48,6 @@
         // &:before {
         //   content: '•';
         // }
-      }
-
-      &-category {
-        @include category;
-
-        & a {
-          @include category;
-          background-color: $color-primary;
-          text-decoration: none;
-        }
-
-        &--dark {
-          @include category;
-          background-color: $color-black !important;
-
-          & a {
-            color: $color-gray !important;
-          }
-        }
       }
     }
   }

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -28,6 +28,7 @@ const Layout = ({
   const cardType = featuredImage ? 'summary_large_image' : 'summary';
 
   const { isDark, toggleDarkMode } = useContext(ThemeContext);
+  console.log('From Layout', isDark);
   return (
     <div className={styles.layout}>
       <Helmet>
@@ -45,7 +46,7 @@ const Layout = ({
         <meta name='twitter:description' content={description} />
         <meta name='og:image' content={cardImage} />
       </Helmet>
-      <Switch value={isDark} toggle={toggleDarkMode} />
+      <Switch value={isDark} toggle={toggleDarkMode} label='switchDarkMode' />
       {children}
     </div>
   );

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -28,7 +28,6 @@ const Layout = ({
   const cardType = featuredImage ? 'summary_large_image' : 'summary';
 
   const { isDark, toggleDarkMode } = useContext(ThemeContext);
-  console.log('From Layout', isDark);
   return (
     <div className={styles.layout}>
       <Helmet>

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -1,6 +1,5 @@
-import React, { useRef, useEffect, useContext } from 'react';
+import React, { useRef, useEffect } from 'react';
 import styles from './Page.module.scss';
-import ThemeContext from '../../context/theme-context';
 
 type Props = {
   title?: string,
@@ -14,16 +13,10 @@ const Page = ({ title, children }: Props) => {
     pageRef.current.scrollIntoView();
   });
 
-  const { isDark } = useContext(ThemeContext);
-
   return (
     <div ref={pageRef} className={styles['page']}>
       <div className={styles['page__inner']}>
-        {title && (
-          <h1 className={styles[`page__title${isDark ? '--dark' : ''}`]}>
-            {title}
-          </h1>
-        )}
+        {title && <h1 className='page__title'>{title}</h1>}
         <div className={styles['page__body']}>{children}</div>
       </div>
     </div>

--- a/src/components/Page/Page.module.scss
+++ b/src/components/Page/Page.module.scss
@@ -8,16 +8,6 @@
     padding: 25px 20px;
   }
 
-  &__title {
-    @include page-title;
-    @include text-shadow($color-primary);
-
-    &--dark {
-      @include page-title;
-      @include text-shadow($color-black);
-    }
-  }
-
   &__body {
     font-size: $typographic-base-font-size;
     @include line-height(1);

--- a/src/components/Post/Content/Content.js
+++ b/src/components/Post/Content/Content.js
@@ -1,8 +1,7 @@
 // @flow
-import React, { useContext } from 'react';
+import React from 'react';
 import moment from 'moment';
 import styles from './Content.module.scss';
-import ThemeContext from '../../../context/theme-context';
 
 type Props = {
   body: string,
@@ -10,23 +9,18 @@ type Props = {
   date: string
 };
 
-const Content = ({ body, title, date }: Props) => {
-  const { isDark } = useContext(ThemeContext);
-  return (
-    <div className={styles['content']}>
-      <h1 className={styles[`content__title${isDark ? '--dark' : ''}`]}>
-        {title}
-      </h1>
-      <p className={styles['content__date']}>
-        <span style={{ fontStyle: 'normal' }}>📌 </span>Published{' '}
-        {moment(date).format('MMMM DD, YYYY')}
-      </p>
-      <div
-        className={styles['content__body']}
-        dangerouslySetInnerHTML={{ __html: body }}
-      />
-    </div>
-  );
-};
+const Content = ({ body, title, date }: Props) => (
+  <div className={styles['content']}>
+    <h1 className='content__title'>{title}</h1>
+    <p className={styles['content__date']}>
+      <span style={{ fontStyle: 'normal' }}>📌 </span>Published{' '}
+      {moment(date).format('MMMM DD, YYYY')}
+    </p>
+    <div
+      className={styles['content__body']}
+      dangerouslySetInnerHTML={{ __html: body }}
+    />
+  </div>
+);
 
 export default Content;

--- a/src/components/Post/Content/Content.module.scss
+++ b/src/components/Post/Content/Content.module.scss
@@ -6,17 +6,6 @@
   padding: 0 15px;
   margin: 0 auto;
 
-  &__title {
-    @include content-title;
-    @include text-shadow($color-primary);
-
-    &--dark {
-      color: $color-white !important;
-      @include content-title;
-      @include text-shadow($color-black);
-    }
-  }
-
   &__date {
     max-width: $layout-post-width;
     font-style: italic;
@@ -71,20 +60,6 @@
 @include breakpoint-md {
   .content {
     padding: 0;
-
-    &__title {
-      font-size: $typographic-base-font-size * 3;
-      @include line-height(2.25);
-      @include margin-top(2.25);
-      @include margin-bottom(1.5);
-
-      &--dark {
-        font-size: $typographic-base-font-size * 3;
-        @include line-height(2.25);
-        @include margin-top(2.25);
-        @include margin-bottom(1.5);
-      }
-    }
 
     &__body {
       font-size: $typographic-base-font-size * 1.125;

--- a/src/components/Post/Tags/Tags.js
+++ b/src/components/Post/Tags/Tags.js
@@ -1,28 +1,20 @@
 // @flow
-import React, { useContext } from 'react';
+import React from 'react';
 import { Link } from 'gatsby';
 import styles from './Tags.module.scss';
-import ThemeContext from '../../../context/theme-context';
 
 type Props = {
   tags: string[],
   tagSlugs: string[]
 };
 
-const Tags = ({ tags, tagSlugs }: Props) => {
-  const { isDark } = useContext(ThemeContext);
-  return (
-    <div className={styles['tags']}>
-      <ul className={styles['tags__list']}>
-        {tagSlugs
-          && tagSlugs.map((slug, i) => (
-            <li className={styles['tags__list-item']} key={tags[i]}>
-              <Link
-                to={slug}
-                className={
-                  styles[`tags__list-item-link${isDark ? '--dark' : ''}`]
-                }
-              >
+const Tags = ({ tags, tagSlugs }: Props) => (
+    <div className={styles["tags"]}>
+      <ul className={styles["tags__list"]}>
+        {tagSlugs &&
+          tagSlugs.map((slug, i) => (
+            <li className={styles["tags__list-item"]} key={tags[i]}>
+              <Link to={slug} className={"tags__list-item-link"}>
                 {tags[i]}
               </Link>
             </li>
@@ -30,6 +22,5 @@ const Tags = ({ tags, tagSlugs }: Props) => {
       </ul>
     </div>
   );
-};
 
 export default Tags;

--- a/src/components/Post/Tags/Tags.module.scss
+++ b/src/components/Post/Tags/Tags.module.scss
@@ -13,26 +13,6 @@
       display: inline-block;
       margin: 5px 0;
       text-transform: lowercase;
-
-      &-link {
-        @include post-tag;
-        background: $color-primary;
-        color: $color-base;
-
-        &:before {
-          content: '#';
-        }
-
-        &--dark {
-          @include post-tag;
-          color: $color-gray !important;
-          background-color: $color-black;
-
-          &:before {
-            content: '#';
-          }
-        }
-      }
     }
   }
 }

--- a/src/components/Sidebar/Author/Author.js
+++ b/src/components/Sidebar/Author/Author.js
@@ -41,10 +41,7 @@ const Author = ({ author }: Props) => {
       </Link>
 
       <h1 className={styles['author__title']}>
-        <Link
-          className={styles[`author__title-link${isDark ? '--dark' : ''}`]}
-          to='/'
-        >
+        <Link className='author__title-link' to='/'>
           &lt;rph />
         </Link>
       </h1>

--- a/src/components/Sidebar/Author/Author.js
+++ b/src/components/Sidebar/Author/Author.js
@@ -1,8 +1,7 @@
 // @flow
-import React, { useContext } from 'react';
+import React from 'react';
 import { graphql, Link, StaticQuery } from 'gatsby';
 import Img from 'gatsby-image';
-import ThemeContext from '../../../context/theme-context';
 import styles from './Author.module.scss';
 
 type Props = {
@@ -13,10 +12,8 @@ type Props = {
   }
 };
 
-const Author = ({ author }: Props) => {
-  const { isDark } = useContext(ThemeContext);
-  return (
-    <div className={styles['author']}>
+const Author = ({ author }: Props) => (
+    <div className={styles["author"]}>
       <Link to='/'>
         <StaticQuery
           query={graphql`
@@ -34,20 +31,19 @@ const Author = ({ author }: Props) => {
             <Img
               fixed={heroImg.childImageSharp.fixed}
               alt="Hi, I'm Caye."
-              className={styles['author__photo']}
+              className={styles["author__photo"]}
             />
           )}
         />
       </Link>
 
-      <h1 className={styles['author__title']}>
+      <h1 className={styles["author__title"]}>
         <Link className='author__title-link' to='/'>
           &lt;rph />
         </Link>
       </h1>
-      <p className={styles['author__subtitle']}>{author.bio}</p>
+      <p className={styles["author__subtitle"]}>{author.bio}</p>
     </div>
   );
-};
 
 export default Author;

--- a/src/components/Sidebar/Author/Author.module.scss
+++ b/src/components/Sidebar/Author/Author.module.scss
@@ -15,23 +15,6 @@
     @include text-shadow($color-primary);
     @include line-height(1.125);
     @include margin(0.5, 0, 0.5, 0);
-
-    // &--dark {
-    //   color: red;
-    // }
-
-    &-link {
-      color: $color-base;
-
-      &--dark {
-        @include text-shadow($color-black);
-      }
-
-      &:hover,
-      &:focus {
-        // color: $color-base;
-      }
-    }
   }
 
   &__subtitle {

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,11 +1,10 @@
 // @flow
-import React, { useContext } from 'react';
+import React from 'react';
 import Author from './Author';
 import Menu from './Menu';
 import Contacts from './Contacts';
 import styles from './Sidebar.module.scss';
 import { useSiteMetadata } from '../../hooks';
-import ThemeContext from '../../context/theme-context';
 
 type Props = {
   isIndex?: boolean,
@@ -14,11 +13,10 @@ type Props = {
 
 const Sidebar = ({ isIndex }: Props) => {
   const { author, menu } = useSiteMetadata();
-  const { isDark } = useContext(ThemeContext);
 
   return (
     <div className={styles['sidebar']}>
-      <div className={styles[`sidebar__inner${isDark ? '--dark' : ''}`]}>
+      <div className='sidebar__inner'>
         <Author author={author} isIndex={isIndex} />
         <Menu menu={menu} />
 

--- a/src/components/Sidebar/Sidebar.module.scss
+++ b/src/components/Sidebar/Sidebar.module.scss
@@ -3,54 +3,16 @@
 
 .sidebar {
   width: 100%;
-  &__inner,
-  &__inner--dark {
-    position: relative;
-    padding: 25px 20px 0;
-  }
 }
 
 @include breakpoint-sm {
   .sidebar {
     lost-column: 5/12;
-
-    &__inner {
-      padding: 30px 20px 0;
-
-      &:after {
-        @include sidebar-divider;
-        background: $color-gray-border;
-        background: linear-gradient(
-          to bottom,
-          $color-gray-border 0%,
-          $color-gray-border 48%,
-          $color-white 100%
-        ) !important;
-      }
-
-      &--dark {
-        padding: 30px 20px 0;
-        &:after {
-          @include sidebar-divider;
-          background: $color-gray-border;
-          background: linear-gradient(
-            to bottom,
-            darken($color-gray, 20%) 0%,
-            darken($color-gray, 20%) 48%,
-            $color-base 100%
-          ) !important;
-        }
-      }
-    }
   }
 }
 
 @include breakpoint-md {
   .sidebar {
     lost-column: 1/3;
-    &__inner,
-    &__inner--dark {
-      padding: 40px;
-    }
   }
 }

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -1,11 +1,20 @@
 import React from 'react';
 import styles from './Switch.module.scss';
 
-const Switch = ({ value, toggle }) => (
-  <div className={styles['switch']}>
-    <input type='checkbox' id='switch' checked={value} onChange={toggle} />
-    <label className={styles['switch__label']} htmlFor='switch'></label>
-  </div>
-);
+const Switch = ({ value, toggle, label }) => {
+  console.log('From Switch', value);
+  return (
+    <div className={styles['switch']}>
+      <input
+        type='checkbox'
+        id='switch'
+        checked={value}
+        onChange={toggle}
+        label={label}
+      />
+      <label className={styles['switch__label']} htmlFor='switch'></label>
+    </div>
+  );
+};
 
 export default Switch;

--- a/src/components/Switch/Switch.js
+++ b/src/components/Switch/Switch.js
@@ -1,20 +1,17 @@
 import React from 'react';
 import styles from './Switch.module.scss';
 
-const Switch = ({ value, toggle, label }) => {
-  console.log('From Switch', value);
-  return (
-    <div className={styles['switch']}>
-      <input
-        type='checkbox'
-        id='switch'
-        checked={value}
-        onChange={toggle}
-        label={label}
-      />
-      <label className={styles['switch__label']} htmlFor='switch'></label>
-    </div>
-  );
-};
+const Switch = ({ value, toggle, label }) => (
+  <div className={styles['switch']}>
+    <input
+      type='checkbox'
+      id='switch'
+      checked={value}
+      onChange={toggle}
+      label={label}
+    />
+    <label className={styles['switch__label']} htmlFor='switch'></label>
+  </div>
+);
 
 export default Switch;

--- a/src/context/theme-context.js
+++ b/src/context/theme-context.js
@@ -5,7 +5,6 @@ const ThemeContext = createContext(false);
 
 const ThemeProvider = ({ children }) => {
   const darkMode = useDarkMode();
-  console.log('From ThemeContext', darkMode);
   return (
     <ThemeContext.Provider
       value={{ isDark: darkMode.value, toggleDarkMode: darkMode.toggle }}

--- a/src/context/theme-context.js
+++ b/src/context/theme-context.js
@@ -4,7 +4,8 @@ import useDarkMode from 'use-dark-mode';
 const ThemeContext = createContext(false);
 
 const ThemeProvider = ({ children }) => {
-  const darkMode = useDarkMode(false);
+  const darkMode = useDarkMode();
+  console.log('From ThemeContext', darkMode);
   return (
     <ThemeContext.Provider
       value={{ isDark: darkMode.value, toggleDarkMode: darkMode.toggle }}


### PR DESCRIPTION
## Description
- Because starter theme used modular scss, first implementation of dark mode was:
   - Check if `isDark: true` via Context
   - Append a `--dark` in classnames, like so:
      ```jsx
      <h1 className={styles[`page__title${isDark ? '--dark' : ''}`]}>
         {title}
      </h1>
      ```

- BUT implementation was buggy. Some elements retained their original classes (see issue)
- Implemented solution: All control flow is moved to scss, like so:
   ```css
   .title {
      (default styles here)
   }
   
   body.dark-mode {
      .title {
         (all color style modifications here)
      }
   }
   ```
- **Lesson learned:** In case of really particular styling, modular scss isn't the best way to go when implementing dark mode (as it should be a global implementation)
- Although in the first place, I should've used less styled elements so it would've been easier to implement dark mode? (Not willing to sacrifice how I want things to look though :cry:)
- **Good news amidst this whole ordeal (including dark mode implementation itself):** Used mixins, and had to _really_ learn Context and useContext so there's that :tada: 

## Related Issues
Closes #18 