### PR TITLE
posts(feat): add socmed share buttons at the end of article

### DIFF
--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -5,11 +5,12 @@ import Author from './Author';
 import Comments from './Comments';
 import Content from './Content';
 // import Meta from './Meta';
+import ShareButtons from './ShareButtons/ShareButtons';
 import Tags from './Tags';
 import Scroll from '../Scroll';
 // import Copyright from '../Sidebar/Copyright/Copyright';
 import styles from './Post.module.scss';
-import { useSiteMetadata } from '../../hooks';
+// import { useSiteMetadata } from '../../hooks';
 import type { Node } from '../../types';
 
 type Props = {
@@ -42,6 +43,7 @@ const Post = ({ post }: Props) => {
         >
           Tweet
         </a> */}
+        <ShareButtons slug={slug} title={title} />
         <Scroll />
         <Author />
       </div>

--- a/src/components/Post/ShareButtons/ShareButtons.js
+++ b/src/components/Post/ShareButtons/ShareButtons.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import classNames from 'classnames';
+import styles from '../../Sidebar/Contacts/Contacts.module.scss';
+import { getIcon } from '../../../utils';
+import Icon from '../../Icon';
+
+const ShareButtons = ({ slug, title }) => {
+  const url = `https://cayeborreo.com${slug}`;
+  const encodedURL = encodeURI(url);
+
+  const tweetContent = `${title} by @mcborreo`;
+  const encodedTweet = encodeURI(tweetContent);
+
+  return (
+    <div className={styles['share-buttons']}>
+      <div
+        style={{ fontWeight: 'bold', float: 'left', margin: '.5rem 1rem 0 0' }}
+      >
+        Share this article:
+      </div>
+      <div className={styles['contacts']}>
+        <ul className={styles['contacts__list']}>
+          <li className={styles['contacts__list-item']}>
+            <div
+              className='fb-share-button'
+              data-href={url}
+              data-layout='button'
+              data-size='large'
+            >
+              <a
+                className={styles['contacts__list-item-link']}
+                href={`https://www.facebook.com/sharer/sharer.php?u=${encodedURL}&amp;src=sdkpreparse`}
+                rel='noopener noreferrer'
+                target='_blank'
+              >
+                <Icon icon={getIcon('facebook')} />
+              </a>
+            </div>
+          </li>
+
+          <li className={styles['contacts__list-item']}>
+            <a
+              className={classNames(
+                styles['contacts__list-item-link'],
+                'twitter-share-button'
+              )}
+              href={`https://twitter.com/intent/tweet?text=${encodedTweet}%20${encodedURL}`}
+              rel='noopener noreferrer'
+              target='_blank'
+            >
+              <Icon icon={getIcon('twitter')} />
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default ShareButtons;

--- a/src/components/Post/ShareButtons/index.js
+++ b/src/components/Post/ShareButtons/index.js
@@ -1,0 +1,2 @@
+// @flow
+export { default } from './ShareButtons';

--- a/src/components/Sidebar/Contacts/Contacts.module.scss
+++ b/src/components/Sidebar/Contacts/Contacts.module.scss
@@ -41,3 +41,8 @@
     }
   }
 }
+
+.share-buttons {
+  @include margin-top(2);
+  @include margin-bottom(0.5);
+}

--- a/src/html.js
+++ b/src/html.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function HTML(props) {
+  return (
+    <html {...props.htmlAttributes}>
+      <head>
+        <meta charSet='utf-8' />
+        <meta httpEquiv='x-ua-compatible' content='ie=edge' />
+        <meta
+          name='viewport'
+          content='width=device-width, initial-scale=1, shrink-to-fit=no'
+        />
+        {props.headComponents}
+      </head>
+      <body {...props.bodyAttributes}>
+        {/* Putting this here for the FB Share Button to work */}
+        <div id='fb-root'></div>
+        <script
+          async
+          defer
+          crossorigin='anonymous'
+          src='https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v4.0'
+        ></script>
+
+        {props.preBodyComponents}
+        <noscript key='noscript' id='gatsby-noscript'>
+          This app works best with JavaScript enabled.
+        </noscript>
+        <div
+          key={'body'}
+          id='___gatsby'
+          dangerouslySetInnerHTML={{ __html: props.body }}
+        />
+        {props.postBodyComponents}
+      </body>
+    </html>
+  );
+}
+
+HTML.propTypes = {
+  htmlAttributes: PropTypes.object,
+  headComponents: PropTypes.array,
+  bodyAttributes: PropTypes.object,
+  preBodyComponents: PropTypes.array,
+  body: PropTypes.string,
+  postBodyComponents: PropTypes.array
+};

--- a/src/utils/get-icon.js
+++ b/src/utils/get-icon.js
@@ -14,6 +14,9 @@ const getIcon = (name: string) => {
     case 'email':
       icon = ICONS.EMAIL;
       break;
+    case 'facebook':
+      icon = ICONS.FACEBOOK;
+      break;
     default:
       icon = {};
       break;


### PR DESCRIPTION
## Description
- Adds share to FB and Twitter links at end of post
- References: [Twitter Developers](https://developer.twitter.com/en/docs/twitter-for-websites/tweet-button/overview.html) and [Facebook for Developers](https://developers.facebook.com/docs/plugins/share-button/)

## Related Issues
Closes #21 